### PR TITLE
chore: Force pip3 usage to install pipenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,15 +31,13 @@ build:
 
 install: install-pipenv
 	@pipenv install 
-	@pipenv run pip install -e .
 
 install-dev: install-pipenv	
 	@pipenv install 
 	@pipenv install --dev
-	@pipenv run pip install -e .
 
 install-pipenv:
-	@pip install pipenv
+	@pip3 install pipenv
 
 test: validate
 	@pipenv run python -m pytest -vv


### PR DESCRIPTION
# PR Details

## Description

Pip (from python2) no longer comes installed with Ubuntu 20 - https://github.com/actions/virtual-environments/issues/1816


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)